### PR TITLE
Update README and Dockerfile to use QUART_ variables instead of FLASK

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ Build the image with `docker build -t <tag> .`. Run it with `docker run -p 5000:
 2. Activate the virtual environment: `source venv/bin/activate`
 3. Install dependencies: `pip install -r requirements-dev.txt`
 4. Install the pre-commit hook: `pre-commit install`
-5. Run the app: `QUART_ENV=development MONGO_USER=<mongo username> MONGO_PASS=<mongo password> MONGO_ENDPOINT=<mongo endpoint> MONGO_PORT=<mongo port> python src/app.py`
+5. Run the app: `QUART_ENV=development QUART_DEBUG=1 MONGO_USER=<mongo username> MONGO_PASS=<mongo password> MONGO_ENDPOINT=<mongo endpoint> MONGO_PORT=<mongo port> python src/app.py`
 6. Make changes and contribute 🙌

--- a/src/app.py
+++ b/src/app.py
@@ -15,9 +15,6 @@ MONGO_PORT = os.environ.get("MONGO_PORT")
 
 app = Quart(__name__, static_folder="public", template_folder="views")
 
-# automatically reload templates in development
-app.config["TEMPLATES_AUTO_RELOAD"] = os.environ.get("QUART_ENV") == "development"
-
 mongo = Motor(
     app, uri=f"mongodb://{MONGO_USER}:{MONGO_PASS}@{MONGO_ENDPOINT}:{MONGO_PORT}/parler"
 )


### PR DESCRIPTION
Just what it says on the tin...

To test:
1. Run the app with `QUART_ENV=development` to trigger the development server
2. Make a change to a template
3. Ensure that the change automatically appears when you reload the page without having to restart the server