### PR TITLE
Search all content fields

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -62,6 +62,15 @@ def get_post_query(username: str, search_content: str) -> Optional[dict]:
                 {
                     "text": content_regex,
                 },
+                {
+                    "media.title": content_regex,
+                },
+                {
+                    "comment.text": content_regex,
+                },
+                {
+                    "echo.text": content_regex,
+                },
             ],
         }
 


### PR DESCRIPTION
Expands the content search to all the `text` fields. Should we also search the `media.excerpt`? I don't think so but also not sure.