### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ WORKDIR /app
 RUN pip install -r requirements.txt
 
 COPY src/ /app
+COPY bin/ /app/bin
 
 CMD ["./bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN pip install -r requirements.txt
 COPY src/ /app
 COPY bin/ /app/bin
 
-CMD ["./bin/run.sh"]
+CMD ["hypercorn", "--bind=0.0.0.0:5000", "app:app"]

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,2 +1,2 @@
 #! /bin/sh
-hypercorn --bind=0.0.0.0:5000 app:app
+hypercorn --bind=0.0.0.0:5000 src/app:app

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,2 +1,2 @@
 #! /bin/sh
-hypercorn --bind=0.0.0.0:5000 src/app:app
+hypercorn --bind=0.0.0.0:5000 app:app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   parler-search:
     build: .
     ports:
-      - 5000:5000
+      - 5005:5000
     env_file:
       - .env


### PR DESCRIPTION
This PR fixes a couple of things:
1. Copies the `bin/` folder into the container (I think this might not be necessary...we could probably just make the contents of that script the actual `CMD` in the dockerfile. This also negates change 2 described below, that can remain as-is. Thoughts?)
1. Fixes the app reference within `run.sh` based on how the files are copied into the container
1. Changes the external port to 5005 to avoid conflicts
