### PR TITLE
Use `X-Forwarded-For` instead of IP

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 from datetime import timedelta
+from typing import Optional
 from urllib.parse import urlencode
 
 from dotenv import load_dotenv
@@ -46,7 +47,12 @@ if QUART_ENV == "development":
 else:
     redis_store = RedisStore(REDIS_URL)
 
-limiter = RateLimiter(app, store=redis_store)
+
+async def key_function() -> Optional[str]:
+    return request.headers.get("X-Forwarded-For", request.remote_addr)
+
+
+limiter = RateLimiter(app, key_function=key_function, store=redis_store)
 
 
 @app.errorhandler(429)


### PR DESCRIPTION
If we don't do this then the inbound IP is used which results in everyone getting rate limited at the same IP:

This is what redis looks like in prod right now:

```
redis:6379> KEYS *
1) "app-about-1-0.5-172.20.0.1"
2) "app-home-1-0.5-172.20.0.1"
3) "app-posts-1-3.0-172.20.0.1"
4) "app-users-1-1.0-172.20.0.1"
```

Using `X-Forwarded-For` should fix this.